### PR TITLE
Added points and toggleable rechargeability

### DIFF
--- a/Assets/Particles.meta
+++ b/Assets/Particles.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5e64c6b85c918a549a5f3f8eb86248d9
+guid: 215fb18a6ad073b438cf4579ce8f6165
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Prefabs/MediumEnemy.prefab
+++ b/Assets/Prefabs/MediumEnemy.prefab
@@ -129,6 +129,7 @@ MonoBehaviour:
   attackRange: 1.5
   attackRate: 0
   enemyHealth: 50
+  enemyValue: 100
   enemyAgent: {fileID: 1632055073798285410}
 --- !u!195 &1632055073798285410
 NavMeshAgent:

--- a/Assets/Script/Enemy.cs
+++ b/Assets/Script/Enemy.cs
@@ -13,6 +13,8 @@ public class Enemy : MonoBehaviour
     private float attackRate;
     [SerializeField]
     private float enemyHealth;
+    [SerializeField]
+    private float enemyValue;
 
     public NavMeshAgent enemyAgent;
 
@@ -100,6 +102,8 @@ public class Enemy : MonoBehaviour
     {
         if (enemyHealth <= 0)
         {
+            GameObject player = GameObject.Find("Player");
+            player.GetComponent<PlayerController>().playerPoints += enemyValue;
             Destroy(gameObject);
         }
     }

--- a/Assets/Script/PlayerController.cs
+++ b/Assets/Script/PlayerController.cs
@@ -64,7 +64,7 @@ public class PlayerController : MonoBehaviourPunCallbacks, IPunObservable
 
     #region Player Point Management
     [Header("Player Point Management")]
-    [SerializeField] private float Points;
+    [SerializeField] public float playerPoints;
     #endregion
 
     #region Components 

--- a/Assets/Script/Weapons.cs
+++ b/Assets/Script/Weapons.cs
@@ -114,7 +114,7 @@ public class Weapons : MonoBehaviour
         playerUI.weaponBattery.maxValue = batteryLevelMax;
         playerUI.weaponBattery.value = batteryLevel;
         
-        if(batteryLevel == 0)
+        if(batteryLevel <= 0)
         {
             playerUI.batteryLevel.sprite = playerUI.emptyBattery;
         }
@@ -183,17 +183,6 @@ public class Weapons : MonoBehaviour
         
     }
 
-    /*
-     * if (isOn)
-     *      light is active
-     *      hitbox is active
-     *      drain battery
-     * else if (!isOn)
-     *      light is inactive
-     *      hitbox is inactive
-     *      battery recharges
-    */
-
     /// <summary>
     /// This method will toggle the flashlight on or off when the left mouse button is clicked.
     /// When checking if it can toggle on, the method will also see if the flashlight is ready
@@ -233,12 +222,13 @@ public class Weapons : MonoBehaviour
             flashlightHitBox.gameObject.SetActive(false);
             playerUI.weaponBattery.maxValue = batteryLevelMax;
             playerUI.weaponBattery.value = batteryLevel;
-            if (batteryLevel <= batteryLevelMax)
-                batteryLevel += batteryRecharge * Time.deltaTime;
-            if (flashLightEmitter.range <= maxFlashlightRange)
-                flashLightEmitter.range += batteryRecharge/2 * Time.deltaTime; //revert to flashLightEmitter.range instsead of batteryRecharge if needed
-            //flashLightEmitter.color += (lightColor) * Time.deltaTime;
-
+            if (canRecharge)
+            {
+                if (batteryLevel <= batteryLevelMax)
+                    batteryLevel += batteryRecharge * Time.deltaTime;
+                if (flashLightEmitter.range <= maxFlashlightRange)
+                    flashLightEmitter.range += batteryRecharge / 2 * Time.deltaTime;
+            }
         }
     }
 }

--- a/Assets/Timelines.meta
+++ b/Assets/Timelines.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cb50dcade30acc645b8b9f0a448d6479
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
- Roaks now give 100 points to player on death
- The "canRecharge" boolean can be toggled in the editor to determine if weapons recharge automatically when turned off or only when a battery is picked up.